### PR TITLE
jsImportに対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin
 /examples/*.js
 /release.zip
+/.haxelib/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## What this repo is
+
+- Haxe externs and stdlib overrides for Node.js.
+- Primary code lives under `src/`.
+- `examples/` are small compilable samples.
+
+## About this fork
+
+- This is a fork of the original `hxnodejs` library.
+- This fork is intended to be installed via `haxelib git`.
+- **CAUTION:** Do not run release or deploy workflows in this fork.
+  - No `Release.hx`.
+  - No `deploy.hxml` or `ci/` publish steps (those target gh-pages for upstream).
+
+## Development environment setup
+
+Run these once so `build.hxml` can find the library:
+
+1) `haxelib newrepo`
+2) `haxelib dev hxnodejs .`
+
+## Typical workflow for changes
+
+1) Make changes in `src/`.
+2) Verify the code compiles and examples build: `haxe build.hxml`
+
+## Notes
+
+- `ImportAll.hx` is a macro helper that forces all types under `src/` to load.
+- `ci/` exists for upstream gh-pages deployment; ignore for this fork.

--- a/src/js/node/Assert.hx
+++ b/src/js/node/Assert.hx
@@ -38,7 +38,11 @@ import js.RegExp;
 
 	@see https://nodejs.org/api/assert.html#assert_assert
 **/
+#if jsImport
+@:js.import(@star "assert")
+#else
 @:jsRequire("assert")
+#end
 extern class Assert {
 	/**
 		In strict mode, assert functions use the comparison in the corresponding strict functions.

--- a/src/js/node/ChildProcess.hx
+++ b/src/js/node/ChildProcess.hx
@@ -324,7 +324,11 @@ typedef ChildProcessSpawnSyncResult = {
 	var error:Error;
 }
 
+#if jsImport
+@:js.import(@star "child_process")
+#else
 @:jsRequire("child_process")
+#end
 extern class ChildProcess {
 	/**
 		Launches a new process with the given `command`, with command line arguments in `args`.

--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -112,7 +112,11 @@ enum abstract ListeningEventAddressType(haxe.extern.EitherType<Int, String>) to 
 	var UDPv6 = "udp6";
 }
 
+#if jsImport
+@:js.import(@star "cluster")
+#else
 @:jsRequire("cluster")
+#end
 extern class ClusterSchedulingPolicies {
 	static final SCHED_NONE:ClusterSchedulingPolicy;
 	static final SCHED_RR:ClusterSchedulingPolicy;
@@ -129,7 +133,11 @@ abstract ClusterSchedulingPolicy(Int) to Int {}
 
 	Also note that, on Windows, it is not yet possible to set up a named pipe server in a worker.
 **/
+#if jsImport
+@:js.import(@star "cluster")
+#else
 @:jsRequire("cluster")
+#end
 extern class Cluster extends EventEmitter<Cluster> {
 	/**
 		A reference to the `Cluster` object returned by node.js module.

--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -113,10 +113,12 @@ enum abstract ListeningEventAddressType(haxe.extern.EitherType<Int, String>) to 
 }
 
 @:jsRequire("cluster")
-extern enum abstract ClusterSchedulingPolicy(Int) {
-	var SCHED_NONE;
-	var SCHED_RR;
+extern class ClusterSchedulingPolicies {
+	static final SCHED_NONE:ClusterSchedulingPolicy;
+	static final SCHED_RR:ClusterSchedulingPolicy;
 }
+
+abstract ClusterSchedulingPolicy(Int) to Int {}
 
 /**
 	A single instance of Node runs in a single thread.

--- a/src/js/node/Constants.hx
+++ b/src/js/node/Constants.hx
@@ -22,7 +22,11 @@
 
 package js.node;
 
+#if jsImport
+@:js.import(@star "constants")
+#else
 @:jsRequire("constants")
+#end
 extern class Constants {
 	static var ENGINE_METHOD_RSA(default, null):Int;
 	static var ENGINE_METHOD_DSA(default, null):Int;

--- a/src/js/node/Crypto.hx
+++ b/src/js/node/Crypto.hx
@@ -63,7 +63,11 @@ enum abstract DiffieHellmanGroupName(String) from String to String {
 
 	It also offers a set of wrappers for OpenSSL's hash, hmac, cipher, decipher, sign and verify methods.
 **/
+#if jsImport
+@:js.import(@star "crypto")
+#else
 @:jsRequire("crypto")
+#end
 extern class Crypto {
 	/**
 		Load and set engine for some/all OpenSSL functions (selected by `flags`).

--- a/src/js/node/Dgram.hx
+++ b/src/js/node/Dgram.hx
@@ -27,7 +27,11 @@ import js.node.dgram.Socket;
 /**
 	Datagram sockets
 **/
+#if jsImport
+@:js.import(@star "dgram")
+#else
 @:jsRequire("dgram")
+#end
 extern class Dgram {
 	/**
 		Creates a datagram `Socket` of the specified types.

--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -132,7 +132,11 @@ extern class DnsError extends Error {
 /**
 	Each DNS query can return one of the following error codes
 **/
+#if jsImport
+@:js.import(@star "dns")
+#else
 @:jsRequire("dns")
+#end
 extern class DnsErrorCodes {
 	/**
 		DNS server returned answer with no data.

--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -133,127 +133,129 @@ extern class DnsError extends Error {
 	Each DNS query can return one of the following error codes
 **/
 @:jsRequire("dns")
-extern enum abstract DnsErrorCode(String) {
+extern class DnsErrorCodes {
 	/**
 		DNS server returned answer with no data.
 	**/
-	var NODATA;
+	static final NODATA:DnsErrorCode;
 
 	/**
 		DNS server claims query was misformatted.
 	**/
-	var FORMERR;
+	static final FORMERR:DnsErrorCode;
 
 	/**
 		DNS server returned general failure.
 	**/
-	var SERVFAIL;
+	static final SERVFAIL:DnsErrorCode;
 
 	/**
 		Domain name not found.
 	**/
-	var NOTFOUND;
+	static final NOTFOUND:DnsErrorCode;
 
 	/**
 		DNS server does not implement requested operation.
 	**/
-	var NOTIMP;
+	static final NOTIMP:DnsErrorCode;
 
 	/**
 		DNS server refused query.
 	**/
-	var REFUSED;
+	static final REFUSED:DnsErrorCode;
 
 	/**
 		Misformatted DNS query.
 	**/
-	var BADQUERY;
+	static final BADQUERY:DnsErrorCode;
 
 	/**
 		Misformatted domain name.
 	**/
-	var BADNAME;
+	static final BADNAME:DnsErrorCode;
 
 	/**
 		Unsupported address family.
 	**/
-	var BADFAMILY;
+	static final BADFAMILY:DnsErrorCode;
 
 	/**
 		Misformatted DNS reply.
 	**/
-	var BADRESP;
+	static final BADRESP:DnsErrorCode;
 
 	/**
 		Could not contact DNS servers.
 	**/
-	var CONNREFUSED;
+	static final CONNREFUSED:DnsErrorCode;
 
 	/**
 		Timeout while contacting DNS servers.
 	**/
-	var TIMEOUT;
+	static final TIMEOUT:DnsErrorCode;
 
 	/**
 		End of file.
 	**/
-	var EOF;
+	static final EOF:DnsErrorCode;
 
 	/**
 		Error reading file.
 	**/
-	var FILE;
+	static final FILE:DnsErrorCode;
 
 	/**
 		Out of memory.
 	**/
-	var NOMEM;
+	static final NOMEM:DnsErrorCode;
 
 	/**
 		Channel is being destroyed.
 	**/
-	var DESTRUCTION;
+	static final DESTRUCTION:DnsErrorCode;
 
 	/**
 		Misformatted string.
 	**/
-	var BADSTR;
+	static final BADSTR:DnsErrorCode;
 
 	/**
 		Illegal flags specified.
 	**/
-	var BADFLAGS;
+	static final BADFLAGS:DnsErrorCode;
 
 	/**
 		Given hostname is not numeric.
 	**/
-	var NONAME;
+	static final NONAME:DnsErrorCode;
 
 	/**
 		Illegal hints flags specified.
 	**/
-	var BADHINTS;
+	static final BADHINTS:DnsErrorCode;
 
 	/**
 		c-ares library initialization not yet performed.
 	**/
-	var NOTINITIALIZED;
+	static final NOTINITIALIZED:DnsErrorCode;
 
 	/**
 		Error loading iphlpapi.dll.
 	**/
-	var LOADIPHLPAPI;
+	static final LOADIPHLPAPI:DnsErrorCode;
 
 	/**
 		Could not find GetNetworkParams function.
 	**/
-	var ADDRGETNETWORKPARAMS;
+	static final ADDRGETNETWORKPARAMS:DnsErrorCode;
 
 	/**
 		DNS query cancelled.
 	**/
-	var CANCELLED;
+	static final CANCELLED:DnsErrorCode;
 }
+
+abstract DnsErrorCode(String) to String {}
 
 typedef DnsLookupCallbackSingle = #if (haxe_ver >= 4) (err:DnsError, address:String,
 		family:DnsAddressFamily) -> Void; #else DnsError->String->DnsAddressFamily->Void #end
@@ -277,7 +279,11 @@ typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
 	they do not use the configuration from /etc/hosts. These functions should be used by developers who do not want
 	to use the underlying operating system's facilities for name resolution, and instead want to always perform DNS queries.
 **/
+#if jsImport
+@:js.import(@star "dns")
+#else
 @:jsRequire("dns")
+#end
 extern class Dns {
 	/**
 		Resolves a `hostname` (e.g. 'google.com') into the first found A (IPv4) or AAAA (IPv6) record.

--- a/src/js/node/Domain.hx
+++ b/src/js/node/Domain.hx
@@ -32,7 +32,11 @@ import js.node.domain.Domain as DomainObject;
 	or causing the program to exit immediately with an error code.
 **/
 @:deprecated
+#if jsImport
+@:js.import(@star "domain")
+#else
 @:jsRequire("domain")
+#end
 extern class Domain {
 	/**
 		Returns a new Domain object.

--- a/src/js/node/Events.hx
+++ b/src/js/node/Events.hx
@@ -37,7 +37,11 @@ import js.Promise;
 
 	@see https://nodejs.org/api/events.html#events_events
  */
+#if jsImport
+@:js.import(@star "events")
+#else
 @:jsRequire("events")
+#end
 extern class Events {
 	/**
 		Creates a `Promise` that is resolved when the `EventEmitter` emits the given

--- a/src/js/node/Fs.hx
+++ b/src/js/node/Fs.hx
@@ -504,7 +504,11 @@ typedef FsRmdirOptions = {
 	When using the synchronous form any exceptions are immediately thrown.
 	You can use try/catch to handle exceptions or allow them to bubble up.
 **/
+#if jsImport
+@:js.import(@star "fs")
+#else
 @:jsRequire("fs")
+#end
 extern class Fs {
 	/**
 		An object containing commonly used constants for file system operations.

--- a/src/js/node/Http.hx
+++ b/src/js/node/Http.hx
@@ -49,7 +49,11 @@ import js.Error;
 	It deals with stream handling and message parsing only. It parses a message into headers and body but
 	it does not parse the actual headers or the body.
 **/
+#if jsImport
+@:js.import(@star "http")
+#else
 @:jsRequire("http")
+#end
 extern class Http {
 	/**
 		A list of the HTTP methods that are supported by the parser.

--- a/src/js/node/Https.hx
+++ b/src/js/node/Https.hx
@@ -32,7 +32,11 @@ import js.node.url.URL;
 	HTTPS is the HTTP protocol over TLS/SSL.
 	In Node.js this is implemented as a separate module.
 **/
+#if jsImport
+@:js.import(@star "https")
+#else
 @:jsRequire("https")
+#end
 extern class Https {
 	/**
 		Returns a new HTTPS web server object.

--- a/src/js/node/Module.hx
+++ b/src/js/node/Module.hx
@@ -31,7 +31,11 @@ import js.node.url.URL;
 
 	@see https://nodejs.org/api/modules.html#modules_the_module_object
 **/
+#if jsImport
+@:js.import(@star "module")
+#else
 @:jsRequire("module")
+#end
 extern class Module {
 	/**
 		The module objects required for the first time by this one.

--- a/src/js/node/Net.hx
+++ b/src/js/node/Net.hx
@@ -70,7 +70,11 @@ enum abstract NetIsIPResult(Int) to Int {
 	The net module provides you with an asynchronous network wrapper.
 	It contains methods for creating both servers and clients (called streams).
 **/
+#if jsImport
+@:js.import(@star "net")
+#else
 @:jsRequire("net")
+#end
 extern class Net {
 	/**
 		Creates a new TCP server.

--- a/src/js/node/Os.hx
+++ b/src/js/node/Os.hx
@@ -29,7 +29,11 @@ import haxe.extern.EitherType;
 
 	@see https://nodejs.org/api/os.html#os_os
 **/
+#if jsImport
+@:js.import(@star "os")
+#else
 @:jsRequire("os")
+#end
 extern class Os {
 	/**
 		A string constant defining the operating system-specific end-of-line marker:

--- a/src/js/node/Path.hx
+++ b/src/js/node/Path.hx
@@ -27,7 +27,11 @@ package js.node;
 
 	@see https://nodejs.org/api/path.html#path_path
 **/
+#if jsImport
+@:js.import(@star "path")
+#else
 @:jsRequire("path")
+#end
 extern class Path {
 	/**
 		The `path.basename()` methods returns the last portion of a `path`, similar to the Unix `basename` command. Trailing directory separators are ignored, see path.sep.

--- a/src/js/node/Punycode.hx
+++ b/src/js/node/Punycode.hx
@@ -23,7 +23,11 @@
 package js.node;
 
 @:deprecated("In a future major version of Node.js punycode module will be removed")
+#if jsImport
+@:js.import(@star "punycode")
+#else
 @:jsRequire("punycode")
+#end
 extern class Punycode {
 	/**
 		Converts a Punycode string of ASCII code points to a string of Unicode code points.

--- a/src/js/node/Querystring.hx
+++ b/src/js/node/Querystring.hx
@@ -30,7 +30,11 @@ import haxe.extern.EitherType;
 
 	@see https://nodejs.org/api/querystring.html#querystring_query_string
 **/
+#if jsImport
+@:js.import(@star "querystring")
+#else
 @:jsRequire("querystring")
+#end
 extern class Querystring {
 	/**
 		The `querystring.decode()` function is an alias for `querystring.parse()`.

--- a/src/js/node/Readline.hx
+++ b/src/js/node/Readline.hx
@@ -33,7 +33,11 @@ import js.node.stream.Writable.IWritable;
 
 	@see https://nodejs.org/api/readline.html#readline_readline
 **/
+#if jsImport
+@:js.import(@star "readline")
+#else
 @:jsRequire("readline")
+#end
 extern class Readline {
 	/**
 		The `readline.clearLine()` method Clears current line of given `TTY` stream

--- a/src/js/node/Repl.hx
+++ b/src/js/node/Repl.hx
@@ -39,7 +39,11 @@ import js.Error;
 
 	@see https://nodejs.org/api/repl.html#repl_repl
 **/
+#if jsImport
+@:js.import(@star "repl")
+#else
 @:jsRequire("repl")
+#end
 extern class Repl {
 	/**
 		The `repl.start()` method creates and starts a `repl.REPLServer` instance.

--- a/src/js/node/Stream.hx
+++ b/src/js/node/Stream.hx
@@ -37,7 +37,12 @@ import js.Promise;
 /**
 	Base class for all streams.
 **/
-@:jsRequire("stream") // the module itself is also a class
+#if jsImport
+@:js.import(@star "stream")
+#else
+@:jsRequire("stream")
+#end
+// the module itself is also a class
 extern class Stream<TSelf:Stream<TSelf>> extends EventEmitter<TSelf> implements IStream {
 	private function new();
 

--- a/src/js/node/StringDecoder.hx
+++ b/src/js/node/StringDecoder.hx
@@ -34,7 +34,11 @@ import js.html.ArrayBufferView;
 
 	@see https://nodejs.org/api/string_decoder.html#string_decoder_string_decoder
 **/
+#if jsImport
+@:js.import("string_decoder", "StringDecoder")
+#else
 @:jsRequire("string_decoder", "StringDecoder")
+#end
 extern class StringDecoder {
 	/**
 		Creates a new `StringDecoder` instance.

--- a/src/js/node/Timers.hx
+++ b/src/js/node/Timers.hx
@@ -10,7 +10,11 @@ import haxe.extern.Rest;
 	The timer functions within Node.js implement a similar API as the timers API provided by Web Browsers
 	but use a different internal implementation that is built around the Node.js Event Loop.
 **/
+#if jsImport
+@:js.import(@star "timers")
+#else
 @:jsRequire("timers")
+#end
 extern class Timers {
 	/**
 		Schedules the "immediate" execution of the callback after I/O events' callbacks.

--- a/src/js/node/Tls.hx
+++ b/src/js/node/Tls.hx
@@ -157,7 +157,11 @@ typedef TlsConnectOptions = {
 	The tls module uses OpenSSL to provide Transport Layer Security
 	and/or Secure Socket Layer: encrypted stream communication.
 **/
+#if jsImport
+@:js.import(@star "tls")
+#else
 @:jsRequire("tls")
+#end
 extern class Tls {
 	/**
 		renegotiation limit, default is 3.

--- a/src/js/node/Tty.hx
+++ b/src/js/node/Tty.hx
@@ -30,6 +30,16 @@ package js.node;
 	instance and process.stdout will be a tty.WriteStream instance. The preferred way to check if node is being
 	run in a TTY context is to check process.stdout.isTTY.
 **/
+#if jsImport
+@:js.import(@star "tty")
+extern class Tty {
+	/**
+		Returns true or false depending on if the `fd` is associated with a terminal.
+	**/
+	static function isatty(fd:Int):Bool;
+
+	@:deprecated("Use tty.ReadStream#setRawMode() instead.")
+#else
 @:jsRequire("tty")
 extern class Tty {
 	/**
@@ -38,5 +48,6 @@ extern class Tty {
 	static function isatty(fd:Int):Bool;
 
 	@:deprecated("Use tty.ReadStream#setRawMode() instead.")
-	static function setRawMode(mode:Bool):Void;
+#end
+static function setRawMode(mode:Bool):Void;
 }

--- a/src/js/node/Url.hx
+++ b/src/js/node/Url.hx
@@ -27,7 +27,11 @@ import js.node.url.URL;
 /**
 	The `url` module provides utilities for URL resolution and parsing.
 **/
+#if jsImport
+@:js.import(@star "url")
+#else
 @:jsRequire("url")
+#end
 extern class Url {
 	/**
 		Returns the Punycode ASCII serialization of the `domain`. If `domain` is an invalid domain, the empty string is returned.

--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -40,7 +40,11 @@ import js.Promise;
 
 	@see https://nodejs.org/api/util.html#util_util
 **/
+#if jsImport
+@:js.import(@star "util")
+#else
 @:jsRequire("util")
+#end
 extern class Util {
 	/**
 		Takes an `async` function (or a function that returns a `Promise`) and returns a function following the

--- a/src/js/node/V8.hx
+++ b/src/js/node/V8.hx
@@ -27,7 +27,11 @@ package js.node;
 
 	Note: The APIs and implementation are subject to change at any time.
 **/
+#if jsImport
+@:js.import(@star "v8")
+#else
 @:jsRequire("v8")
+#end
 extern class V8 {
 	static function getHeapStatistics():V8HeapStatistics;
 

--- a/src/js/node/Vm.hx
+++ b/src/js/node/Vm.hx
@@ -36,7 +36,11 @@ typedef VmRunOptions = {
 	Using this class JavaScript code can be compiled and
 	run immediately or compiled, saved, and run later.
 **/
+#if jsImport
+@:js.import(@star "vm")
+#else
 @:jsRequire("vm")
+#end
 extern class Vm {
 	/**
 		Compiles `code`, runs it and returns the result.

--- a/src/js/node/Zlib.hx
+++ b/src/js/node/Zlib.hx
@@ -69,7 +69,11 @@ typedef ZlibOptions = {
 	This provides bindings to Gzip/Gunzip, Deflate/Inflate, and DeflateRaw/InflateRaw classes.
 	Each class takes the same options, and is a readable/writable Stream.
 **/
+#if jsImport
+@:js.import(@star "zlib")
+#else
 @:jsRequire("zlib")
+#end
 extern class Zlib {
 	/**
 		Allowed `flush` values.

--- a/src/js/node/assert/AssertionError.hx
+++ b/src/js/node/assert/AssertionError.hx
@@ -33,7 +33,11 @@ import js.Error;
 
 	@see https://nodejs.org/api/assert.html#assert_class_assert_assertionerror
 **/
+#if jsImport
+@:js.import("assert", "AssertionError")
+#else
 @:jsRequire("assert", "AssertionError")
+#end
 extern class AssertionError extends Error {
 	/**
 		A subclass of Error that indicates the failure of an assertion.

--- a/src/js/node/buffer/Buffer.hx
+++ b/src/js/node/buffer/Buffer.hx
@@ -40,7 +40,11 @@ import js.html.Uint8Array;
 
 	@see https://nodejs.org/api/buffer.html#buffer_class_buffer
 **/
+#if jsImport
+@:js.import("buffer", "Buffer")
+#else
 @:jsRequire("buffer", "Buffer")
+#end
 extern class Buffer extends Uint8Array {
 	/**
 		Allocates a new buffer.

--- a/src/js/node/buffer/SlowBuffer.hx
+++ b/src/js/node/buffer/SlowBuffer.hx
@@ -38,7 +38,11 @@ package js.node.buffer;
 	undue memory retention in their applications.
 **/
 @:deprecated("SlowBuffer is deprecated, use Buffer.allocUnsafeSlow() instead")
+#if jsImport
+@:js.import("buffer", "SlowBuffer")
+#else
 @:jsRequire("buffer", "SlowBuffer")
+#end
 extern class SlowBuffer extends Buffer {
 	/**
 		Allocates a new `SlowBuffer` of `size` bytes.

--- a/src/js/node/console/Console.hx
+++ b/src/js/node/console/Console.hx
@@ -32,7 +32,11 @@ import js.node.stream.Writable;
 
 	@see https://nodejs.org/api/console.html#console_class_console
 **/
+#if jsImport
+@:js.import("console", "Console")
+#else
 @:jsRequire("console", "Console")
+#end
 extern class Console {
 	/**
 		Creates a new `Console` with one or two writable stream instances. `stdout` is a writable stream to print log or info output.

--- a/src/js/node/crypto/Certificate.hx
+++ b/src/js/node/crypto/Certificate.hx
@@ -28,7 +28,11 @@ import js.node.Buffer;
 	SPKAC is a Certificate Signing Request mechanism originally implemented by Netscape
 	and now specified formally as part of HTML5's keygen element.
 **/
+#if jsImport
+@:js.import("crypto", "Certificate")
+#else
 @:jsRequire("crypto", "Certificate")
+#end
 extern class Certificate {
 	function new();
 

--- a/src/js/node/dgram/Socket.hx
+++ b/src/js/node/dgram/Socket.hx
@@ -116,7 +116,11 @@ typedef SocketBindOptions = {
 	Encapsulates the datagram functionality.
 	It should be created via `Dgram.createSocket`.
 **/
+#if jsImport
+@:js.import("dgram", "Socket")
+#else
 @:jsRequire("dgram", "Socket")
+#end
 extern class Socket extends EventEmitter<Socket> {
 	@:overload(function(type:SocketType, ?callback:MessageListener):Void {})
 	private function new(options:SocketOptions, ?callback:MessageListener);

--- a/src/js/node/events/EventEmitter.hx
+++ b/src/js/node/events/EventEmitter.hx
@@ -62,7 +62,11 @@ enum abstract EventEmitterEvent<T:Function>(Event<T>) to Event<T> {
 
 	@see https://nodejs.org/api/events.html#events_class_eventemitter
 **/
+#if jsImport
+@:js.import("events", "EventEmitter")
+#else
 @:jsRequire("events", "EventEmitter")
+#end
 extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 	function new();
 

--- a/src/js/node/http/Agent.hx
+++ b/src/js/node/http/Agent.hx
@@ -54,7 +54,11 @@ import js.Error;
 	An agent may also be used for an individual request. By providing `{agent: false}` as an option to the `http.get()` or `http.request()` functions,
 	a one-time use `Agent` with default options will be used for the client connection.
 **/
+#if jsImport
+@:js.import("http", "Agent")
+#else
 @:jsRequire("http", "Agent")
+#end
 extern class Agent {
 	/**
 		`options` in socket.connect() are also supported.

--- a/src/js/node/http/ClientRequest.hx
+++ b/src/js/node/http/ClientRequest.hx
@@ -115,7 +115,11 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 
 	Node.js does not check whether Content-Length and the length of the body which has been transmitted are equal or not.
 **/
+#if jsImport
+@:js.import("http", "ClientRequest")
+#else
 @:jsRequire("http", "ClientRequest")
+#end
 extern class ClientRequest extends Writable<ClientRequest> {
 	/**
 		Marks the request as aborting. Calling this will cause remaining data in the response to be dropped and the socket to be destroyed.

--- a/src/js/node/http/IncomingMessage.hx
+++ b/src/js/node/http/IncomingMessage.hx
@@ -53,7 +53,11 @@ enum abstract IncomingMessageeEvent<T:haxe.Constraints.Function>(Event<T>) to Ev
 
 	It implements the `Readable Stream` interface, as well as the following additional events, methods, and properties.
 **/
+#if jsImport
+@:js.import("http", "IncomingMessage")
+#else
 @:jsRequire("http", "IncomingMessage")
+#end
 extern class IncomingMessage extends Readable<IncomingMessage> {
 	/**
 		The `aborted` property will be `true` if the request has been aborted.

--- a/src/js/node/http/Server.hx
+++ b/src/js/node/http/Server.hx
@@ -137,7 +137,11 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 /**
 	This class inherits `from net.Server`.
 **/
+#if jsImport
+@:js.import("http", "Server")
+#else
 @:jsRequire("http", "Server")
+#end
 extern class Server extends js.node.net.Server {
 	/**
 		Limit the amount of time the parser will wait to receive the complete HTTP headers.

--- a/src/js/node/http/ServerResponse.hx
+++ b/src/js/node/http/ServerResponse.hx
@@ -49,7 +49,11 @@ enum abstract ServerResponseEvent<T:haxe.Constraints.Function>(Event<T>) to Even
 	This object is created internally by an HTTP server — not by the user.
 	It is passed as the second parameter to the 'request' event.
 **/
+#if jsImport
+@:js.import("http", "ServerResponse")
+#else
 @:jsRequire("http", "ServerResponse")
+#end
 extern class ServerResponse extends Writable<ServerResponse> {
 	/**
 		This method adds HTTP trailing headers (a header but at the end of the message) to the response.

--- a/src/js/node/https/Agent.hx
+++ b/src/js/node/https/Agent.hx
@@ -26,7 +26,11 @@ package js.node.https;
 	An Agent object for HTTPS similar to `http.Agent`.
 	See [https.request](https://nodejs.org/api/http.html#http_http_request_options_callback) for more information.
 **/
+#if jsImport
+@:js.import("https", "Agent")
+#else
 @:jsRequire("https", "Agent")
+#end
 extern class Agent extends js.node.http.Agent {
 	function new(?options:HttpsAgentOptions);
 }

--- a/src/js/node/https/Server.hx
+++ b/src/js/node/https/Server.hx
@@ -26,5 +26,9 @@ package js.node.https;
 	This class is a subclass of `tls.Server` and emits events same as `http.Server`.
 	See [http.Server](https://nodejs.org/api/http.html#http_class_http_server) for more information.
 **/
+#if jsImport
+@:js.import("https", "Server")
+#else
 @:jsRequire("https", "Server")
+#end
 extern class Server extends js.node.tls.Server {}

--- a/src/js/node/net/Server.hx
+++ b/src/js/node/net/Server.hx
@@ -83,7 +83,11 @@ typedef ServerListenOptionsUnix = {
 /**
 	This class is used to create a TCP or local server.
 **/
+#if jsImport
+@:js.import("net", "Server")
+#else
 @:jsRequire("net", "Server")
+#end
 extern class Server extends EventEmitter<Server> {
 	/**
 		Begin accepting connections on the specified `port` and `hostname`.

--- a/src/js/node/net/Socket.hx
+++ b/src/js/node/net/Socket.hx
@@ -203,7 +203,11 @@ enum abstract SocketAdressFamily(String) to String {
 	var IPv6 = "IPv6";
 }
 
+#if jsImport
+@:js.import("net", "Socket")
+#else
 @:jsRequire("net", "Socket")
+#end
 extern class Socket extends js.node.stream.Duplex<Socket> {
 	/**
 		Construct a new socket object.

--- a/src/js/node/repl/REPLServer.hx
+++ b/src/js/node/repl/REPLServer.hx
@@ -64,7 +64,11 @@ enum abstract REPLServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T>
 
 	@see https://nodejs.org/api/repl.html#repl_class_replserver
 **/
+#if jsImport
+@:js.import("repl", "REPLServer")
+#else
 @:jsRequire("repl", "REPLServer")
+#end
 extern class REPLServer extends EventEmitter<REPLServer> {
 	/**
 		It is possible to expose a variable to the REPL explicitly by assigning it to the `context` object associated

--- a/src/js/node/stream/Duplex.hx
+++ b/src/js/node/stream/Duplex.hx
@@ -149,7 +149,11 @@ enum abstract DuplexEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 	@see https://nodejs.org/api/stream.html#stream_class_stream_duplex
 **/
+#if jsImport
+@:js.import("stream", "Duplex")
+#else
 @:jsRequire("stream", "Duplex")
+#end
 extern class Duplex<TSelf:Duplex<TSelf>> extends Readable<TSelf> implements IDuplex {
 	// --------- Writable interface implementation ----------------------------
 

--- a/src/js/node/stream/PassThrough.hx
+++ b/src/js/node/stream/PassThrough.hx
@@ -30,7 +30,11 @@ package js.node.stream;
 
 	@see https://nodejs.org/api/stream.html#stream_class_stream_passthrough
 **/
+#if jsImport
+@:js.import("stream", "PassThrough")
+#else
 @:jsRequire("stream", "PassThrough")
+#end
 extern class PassThrough extends Transform<PassThrough> {
 	function new();
 }

--- a/src/js/node/stream/Readable.hx
+++ b/src/js/node/stream/Readable.hx
@@ -106,7 +106,11 @@ enum abstract ReadableEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 /**
 	@see https://nodejs.org/api/stream.html#stream_class_stream_readable
 **/
+#if jsImport
+@:js.import("stream", "Readable")
+#else
 @:jsRequire("stream", "Readable")
+#end
 extern class Readable<TSelf:Readable<TSelf>> extends Stream<TSelf> implements IReadable {
 	/**
 		Destroy the stream. Optionally emit an `'error'` event, and emit a `'close'` event unless `emitClose` is set in `false`.

--- a/src/js/node/stream/Transform.hx
+++ b/src/js/node/stream/Transform.hx
@@ -34,7 +34,11 @@ import js.Error;
 
 	@see https://nodejs.org/api/stream.html#stream_implementing_a_transform_stream
 **/
+#if jsImport
+@:js.import("stream", "Transform")
+#else
 @:jsRequire("stream", "Transform")
+#end
 extern class Transform<TSelf:Transform<TSelf>> extends Duplex<TSelf> implements ITransform {
 	function new(?options:TransformNewOptions);
 

--- a/src/js/node/stream/Writable.hx
+++ b/src/js/node/stream/Writable.hx
@@ -105,7 +105,11 @@ enum abstract WritableEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		- child process stdin
 		- process.stdout, process.stderr
 **/
+#if jsImport
+@:js.import("stream", "Writable")
+#else
 @:jsRequire("stream", "Writable")
+#end
 extern class Writable<TSelf:Writable<TSelf>> extends Stream<TSelf> implements IWritable {
 	/**
 		The `writable.cork()` method forces all written data to be buffered in memory.

--- a/src/js/node/tls/Server.hx
+++ b/src/js/node/tls/Server.hx
@@ -98,7 +98,11 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	This class is a subclass of `net.Server` and has the same methods on it.
 	Instead of accepting just raw TCP connections, this accepts encrypted connections using TLS or SSL.
 **/
+#if jsImport
+@:js.import("tls", "Server")
+#else
 @:jsRequire("tls", "Server")
+#end
 extern class Server extends js.node.net.Server {
 	/**
 		Returns `Buffer` instance holding the keys currently used for encryption/decryption of the TLS Session Tickets.

--- a/src/js/node/tls/TLSSocket.hx
+++ b/src/js/node/tls/TLSSocket.hx
@@ -83,7 +83,11 @@ typedef TLSSocketOptions = {
 
 	Its `encrypted` field is always true.
 **/
+#if jsImport
+@:js.import("tls", "TLSSocket")
+#else
 @:jsRequire("tls", "TLSSocket")
+#end
 extern class TLSSocket extends js.node.net.Socket {
 	/**
 		Construct a new TLSSocket object from existing TCP socket.

--- a/src/js/node/tty/ReadStream.hx
+++ b/src/js/node/tty/ReadStream.hx
@@ -27,7 +27,11 @@ package js.node.tty;
 	In normal circumstances, process.stdin will be the only tty.ReadStream instance
 	in any node program (only when isatty(0) is true).
 **/
+#if jsImport
+@:js.import("tty", "ReadStream")
+#else
 @:jsRequire("tty", "ReadStream")
+#end
 extern class ReadStream extends js.node.net.Socket {
 	/**
 		A boolean that is initialized to false.

--- a/src/js/node/tty/WriteStream.hx
+++ b/src/js/node/tty/WriteStream.hx
@@ -39,7 +39,11 @@ enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	In normal circumstances, process.stdout will be the only tty.WriteStream instance
 	ever created (and only when isatty(1) is true).
 **/
+#if jsImport
+@:js.import("tty", "WriteStream")
+#else
 @:jsRequire("tty", "WriteStream")
+#end
 extern class WriteStream extends js.node.net.Socket {
 	/**
 		The number of columns the TTY currently has.

--- a/src/js/node/url/URL.hx
+++ b/src/js/node/url/URL.hx
@@ -26,7 +26,11 @@ package js.node.url;
 	Browser-compatible URL class, implemented by following the WHATWG URL Standard.
 	[Examples of parsed URLs](https://url.spec.whatwg.org/#example-url-parsing) may be found in the Standard itself.
 **/
+#if jsImport
+@:js.import("url", "URL")
+#else
 @:jsRequire("url", "URL")
+#end
 extern class URL {
 	/**
 		Creates a new `URL` object by parsing the `input` relative to the `base`.

--- a/src/js/node/url/URLSearchParams.hx
+++ b/src/js/node/url/URLSearchParams.hx
@@ -32,7 +32,11 @@ import js.node.Iterator;
 	The WHATWG `URLSearchParams` interface and the `querystring` module have similar purpose,
 	but the purpose of the querystring module is more general, as it allows the customization of delimiter characters (`&` and` `=`). On the other hand, this API is designed purely for URL query strings.
 **/
+#if jsImport
+@:js.import("url", "URLSearchParams")
+#else
 @:jsRequire("url", "URLSearchParams")
+#end
 extern class URLSearchParams {
 	@:overload(function(init:String):Void {})
 	@:overload(function(obj:Dynamic<String>):Void {})

--- a/src/js/node/util/Inspect.hx
+++ b/src/js/node/util/Inspect.hx
@@ -25,7 +25,11 @@ package js.node.util;
 import haxe.DynamicAccess;
 import js.node.Util.InspectOptions;
 
+#if jsImport
+@:js.import("util", "inspect")
+#else
 @:jsRequire("util", "inspect")
+#end
 extern class Inspect {
 	/**
 		The `util.inspect()` method returns a string representation of `object` that is intended for debugging.

--- a/src/js/node/util/Promisify.hx
+++ b/src/js/node/util/Promisify.hx
@@ -30,7 +30,11 @@ import js.lib.Promise;
 import js.Promise;
 #end
 
+#if jsImport
+@:js.import("util", "promisify")
+#else
 @:jsRequire("util", "promisify")
+#end
 extern class Promisify {
 	/**
 		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback

--- a/src/js/node/util/TextDecoder.hx
+++ b/src/js/node/util/TextDecoder.hx
@@ -36,7 +36,11 @@ import js.html.ArrayBufferView;
 
 	@see https://nodejs.org/api/util.html#util_class_util_textdecoder
 **/
+#if jsImport
+@:js.import("util", "TextDecoder")
+#else
 @:jsRequire("util", "TextDecoder")
+#end
 extern class TextDecoder {
 	/**
 		Creates an new `TextDecoder` instance.

--- a/src/js/node/util/TextEncoder.hx
+++ b/src/js/node/util/TextEncoder.hx
@@ -33,7 +33,11 @@ import js.html.Uint8Array;
 
 	@see https://nodejs.org/api/util.html#util_class_util_textencoder
 **/
+#if jsImport
+@:js.import("util", "TextEncoder")
+#else
 @:jsRequire("util", "TextEncoder")
+#end
 extern class TextEncoder {
 	function new();
 

--- a/src/js/node/util/Types.hx
+++ b/src/js/node/util/Types.hx
@@ -27,7 +27,11 @@ package js.node.util;
 
 	@see https://nodejs.org/api/util.html#util_util_types
 **/
+#if jsImport
+@:js.import("util", "types")
+#else
 @:jsRequire("util", "types")
+#end
 extern class Types {
 	/**
 		Returns `true` if the value is a built-in `ArrayBuffer` or `SharedArrayBuffer` instance.

--- a/src/js/node/vm/Script.hx
+++ b/src/js/node/vm/Script.hx
@@ -62,7 +62,11 @@ typedef ScriptRunOptions = {
 /**
 	A class for holding precompiled scripts, and running them in specific sandboxes.
 **/
+#if jsImport
+@:js.import("vm", "Script")
+#else
 @:jsRequire("vm", "Script")
+#end
 extern class Script {
 	/**
 		Creating a new `Script` compiles `code` but does not run it. Instead, the created `Script` object

--- a/src/js/node/zlib/Deflate.hx
+++ b/src/js/node/zlib/Deflate.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Compress data using deflate.
 **/
+#if jsImport
+@:js.import("zlib", "Deflate")
+#else
 @:jsRequire("zlib", "Deflate")
+#end
 extern class Deflate extends Zlib {}

--- a/src/js/node/zlib/DeflateRaw.hx
+++ b/src/js/node/zlib/DeflateRaw.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Compress data using deflate, and do not append a zlib header.
 **/
+#if jsImport
+@:js.import("zlib", "DeflateRaw")
+#else
 @:jsRequire("zlib", "DeflateRaw")
+#end
 extern class DeflateRaw extends Zlib {}

--- a/src/js/node/zlib/Gunzip.hx
+++ b/src/js/node/zlib/Gunzip.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Decompress a gzip stream.
 **/
+#if jsImport
+@:js.import("zlib", "Gunzip")
+#else
 @:jsRequire("zlib", "Gunzip")
+#end
 extern class Gunzip extends Zlib {}

--- a/src/js/node/zlib/Gzip.hx
+++ b/src/js/node/zlib/Gzip.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Compress data using gzip.
 **/
+#if jsImport
+@:js.import("zlib", "Gzip")
+#else
 @:jsRequire("zlib", "Gzip")
+#end
 extern class Gzip extends Zlib {}

--- a/src/js/node/zlib/Inflate.hx
+++ b/src/js/node/zlib/Inflate.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Decompress a deflate stream.
 **/
+#if jsImport
+@:js.import("zlib", "Inflate")
+#else
 @:jsRequire("zlib", "Inflate")
+#end
 extern class Inflate extends Zlib {}

--- a/src/js/node/zlib/InflateRaw.hx
+++ b/src/js/node/zlib/InflateRaw.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Decompress a raw deflate stream.
 **/
+#if jsImport
+@:js.import("zlib", "InflateRaw")
+#else
 @:jsRequire("zlib", "InflateRaw")
+#end
 extern class InflateRaw extends Zlib {}

--- a/src/js/node/zlib/Unzip.hx
+++ b/src/js/node/zlib/Unzip.hx
@@ -25,5 +25,9 @@ package js.node.zlib;
 /**
 	Decompress either a Gzip- or Deflate-compressed stream by auto-detecting the header.
 **/
+#if jsImport
+@:js.import("zlib", "Unzip")
+#else
 @:jsRequire("zlib", "Unzip")
+#end
 extern class Unzip extends Zlib {}


### PR DESCRIPTION
## 概要

`jsImport` ライブラリーと組み合わせて利用できるように `hxnodejs` 全体を拡張する。

## 破壊的変更

jsImport対応準備のため、下記の extern enum abstract を extern class に変更
かつ、複数形にリネーム（単数形は個別の値のほうに使用するため）

- `Cluster.hx`: `ClusterSchedulingPolicy`
- `Dns.hx`: `DnsErrorCode`

## 非破壊的拡張

すべての `@:jsRequire` 出現箇所について、`@:js.import` を追加。
`jsImport` ライブラリーの利用有無によって切り替わるように

## その他

- 開発環境構築をしやすいよう `.gitignore` に `/.haxelib/` を追加
- `AGENTS.md` 追加